### PR TITLE
Hotfix/3.11.1

### DIFF
--- a/ZenPacks/zenoss/ZenJMX/zenjmx.py
+++ b/ZenPacks/zenoss/ZenJMX/zenjmx.py
@@ -584,12 +584,18 @@ class ZenJMXTask(ObservableMixin):
         rrdConf = dsConfig.rrdConfig.get(dataPointId)
         type = rrdConf.rrdType
         if(type in ('COUNTER', 'DERIVE')):
-            parts = str(dpValue).split('.')
-            if len(parts) == 2 and int(parts[1]) == 0:
-                #if the value just has trailing zeros treat as int
-                dpValue = int(float(dpValue))
-            elif len(parts)>=2:
+            try:
+                # cast to float first because long('100.0') will fail with a
+                # ValueError
+                dpValue = long(float(dpValue))
+            except (TypeError, ValueError):
                 log.warning("value %s not valid for derive or counter data points", dpValue)
+        else:
+            try:
+                dpValue = float(dpValue)
+            except (TypeError, ValueError):
+                log.warning("value %s not valid for data point", dpValue)
+
         if not rrdConf:
             log.info(
                 'No RRD config found for device %s datasource %s datapoint %s' \

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # These variables are overwritten by Zenoss when the ZenPack is exported
 # or saved.  Do not modify them directly here.
 NAME = "ZenPacks.zenoss.ZenJMX"
-VERSION = "3.11.0"
+VERSION = "3.11.1dev"
 AUTHOR = "Zenoss"
 LICENSE = ""
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss']


### PR DESCRIPTION
Fixes ZENDESK-102389

Changed "storeRRD" method in zenjmx.py to follow the RRDUtil "put" method.