### PR TITLE
XML External Entity vulnerability in zenjmx

### DIFF
--- a/ZenPacks/zenoss/ZenJMX/pom.xml
+++ b/ZenPacks/zenoss/ZenJMX/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.xmlrpc</groupId>
       <artifactId>xmlrpc-server</artifactId>
-      <version>3.0</version>
+      <version>3.1.3</version>
       <exclusions>
         <exclusion>
           <groupId>xml-apis</groupId>


### PR DESCRIPTION
ZPS-5765.

Bumping xmlrpc-server-3.0 with dependencies
to xmlrpc-server-3.1.3